### PR TITLE
Mark []byte passed to Sum64 as noescape

### DIFF
--- a/xxhash_amd64.go
+++ b/xxhash_amd64.go
@@ -4,6 +4,7 @@
 
 package xxhash
 
+//go:noescape
 func sum64(b []byte) uint64
 
 func writeBlocks(x *xxh, b []byte) []byte

--- a/xxhash_test.go
+++ b/xxhash_test.go
@@ -13,6 +13,18 @@ import (
 	"github.com/spaolacci/murmur3"
 )
 
+var result uint64
+
+func BenchmarkStringHash(b *testing.B) {
+	const s = "abcdefghijklmnop"
+	var r uint64
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		r = Sum64([]byte(s))
+	}
+	result = r
+}
+
 func TestSum(t *testing.T) {
 	for i, tt := range []struct {
 		input string


### PR DESCRIPTION
The compiler cannot tell if arguments passed to an asm function escape
so it assumes that they always do. Mark arguments passed to Sum64 as
noescape so any temporary created from a []byte(string) conversion does
not escape.

```
% benchstat {old,new}.txt
name          old time/op    new time/op    delta
StringHash-4    80.8ns ± 4%    20.8ns ± 0%   -74.25%   (p=0.000 n=10+9)

name          old alloc/op   new alloc/op   delta
StringHash-4     16.0B ± 0%     0.0B ±NaN%  -100.00%  (p=0.000 n=10+10)

name          old allocs/op  new allocs/op  delta
StringHash-4      1.00 ± 0%     0.00 ±NaN%  -100.00%  (p=0.000 n=10+10)
```