### PR TITLE
Modify unsafe string to byte slice conversion in Sum64String

### DIFF
--- a/xxhash.go
+++ b/xxhash.go
@@ -44,8 +44,9 @@ func Sum64String(s string) uint64 {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = uintptr(unsafe.Pointer(sh.Data))
-	bh.Len = sh.Len
-	bh.Cap = sh.Len
+	l := len(s)
+	bh.Len = l
+	bh.Cap = l
 	return Sum64(b)
 }
 


### PR DESCRIPTION
Hello, I think there might be a race condition in `Sum64String` which could be mitigated with a minor change. The gist of the issue is that Go's garbage collector can collect objects that are still in scope but no longer referenced (see, for example, this [issue](https://github.com/golang/go/issues/9046) and this [post on reddit](https://www.reddit.com/r/golang/comments/45ynih/premature_gc_on_file_handles/)). Consequently, `Sum64String` may suffer from the following race condition:

```
func Sum64String(s string) uint64 {
	var b []byte
	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
>>>
Go's garbage collector runs here and interrupts this function after the previous line.
It sees that `s` is not used after this point and determines that it is eligible for collection.
`sh` contains a `uintptr`, so the garbage collector does not consider this pointer to be a
live reference to an object on the heap. Consequently, the garbage collector determines
that there are no live references to the bytes that `s` pointed to and frees them.
>>>
	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
	bh.Data = uintptr(unsafe.Pointer(sh.Data))
	bh.Len = sh.Len
	bh.Cap = sh.Len
	return Sum64(b)
}
```

I believe we can get around this problem by using `s` after we set `b` to point to the same bytes with the line:

```
l := len(s)
```

In this way the garbage collector will see that `s` is used after `b`'s `Data` field is updated to point to the underlying bytes and the bytes must be live until them.