### PR TITLE
Separate unsafe code for App Engine support.

### DIFF
--- a/xxhash.go
+++ b/xxhash.go
@@ -5,8 +5,6 @@ package xxhash
 import (
 	"encoding/binary"
 	"hash"
-	"reflect"
-	"unsafe"
 )
 
 const (
@@ -30,25 +28,6 @@ var (
 	prime4v = prime4
 	prime5v = prime5
 )
-
-// Sum64String computes the 64-bit xxHash digest of s.
-// It may be faster than Sum64([]byte(s)) by avoiding a copy.
-//
-// TODO(caleb): Consider removing this if an optimization is ever added to make
-// it unnecessary: https://golang.org/issue//2205.
-//
-// TODO(caleb): We still have a function call; we could instead write Go/asm
-// copies of Sum64 for strings to squeeze out a bit more speed.
-func Sum64String(s string) uint64 {
-	// See https://groups.google.com/d/msg/golang-nuts/dcjzJy-bSpw/tcZYBzQqAQAJ
-	// for some discussion about this unsafe conversion.
-	var b []byte
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
-	bh.Len = len(s)
-	bh.Cap = len(s)
-	return Sum64(b)
-}
 
 type xxh struct {
 	v1    uint64

--- a/xxhash_safe.go
+++ b/xxhash_safe.go
@@ -1,0 +1,10 @@
+// +build appengine
+
+// This file contains the safe implementations of otherwise unsafe-using code.
+
+package xxhash
+
+// Sum64String computes the 64-bit xxHash digest of s.
+func Sum64String(s string) uint64 {
+	return Sum64([]byte(s))
+}

--- a/xxhash_unsafe.go
+++ b/xxhash_unsafe.go
@@ -1,0 +1,30 @@
+// +build !appengine
+
+// This file encapsulates all unsafe usage for easy safe builds.
+// xxhash_safe.go contains the safe implementations.
+
+package xxhash
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// Sum64String computes the 64-bit xxHash digest of s.
+// It may be faster than Sum64([]byte(s)) by avoiding a copy.
+//
+// TODO(caleb): Consider removing this if an optimization is ever added to make
+// it unnecessary: https://golang.org/issue//2205.
+//
+// TODO(caleb): We still have a function call; we could instead write Go/asm
+// copies of Sum64 for strings to squeeze out a bit more speed.
+func Sum64String(s string) uint64 {
+	// See https://groups.google.com/d/msg/golang-nuts/dcjzJy-bSpw/tcZYBzQqAQAJ
+	// for some discussion about this unsafe conversion.
+	var b []byte
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = (*reflect.StringHeader)(unsafe.Pointer(&s)).Data
+	bh.Len = len(s)
+	bh.Cap = len(s)
+	return Sum64(b)
+}


### PR DESCRIPTION
Unfortunately App Engine doesn't allow `unsafe`. This PR makes the library compatible with App Engine by falling back to a safe implementation with the appengine build tag.