### PR TITLE
Change writeBlocks signature to avoid making xxh escape

### DIFF
--- a/xxhash.go
+++ b/xxhash.go
@@ -83,7 +83,8 @@ func (x *xxh) Write(b []byte) (n int, err error) {
 
 	if len(b) >= 32 {
 		// One or more full blocks left.
-		b = writeBlocks(x, b)
+		nw := writeBlocks(x, b)
+		b = b[nw:]
 	}
 
 	// Store any remaining partial block.

--- a/xxhash_amd64.go
+++ b/xxhash_amd64.go
@@ -9,4 +9,5 @@ package xxhash
 //go:noescape
 func Sum64(b []byte) uint64
 
-func writeBlocks(x *xxh, b []byte) []byte
+//go:noescape
+func writeBlocks(x *xxh, b []byte) int

--- a/xxhash_other.go
+++ b/xxhash_other.go
@@ -61,8 +61,9 @@ func Sum64(b []byte) uint64 {
 	return h
 }
 
-func writeBlocks(x *xxh, b []byte) []byte {
+func writeBlocks(x *xxh, b []byte) int {
 	v1, v2, v3, v4 := x.v1, x.v2, x.v3, x.v4
+	n := len(b)
 	for len(b) >= 32 {
 		v1 = round(v1, u64(b[0:8:len(b)]))
 		v2 = round(v2, u64(b[8:16:len(b)]))
@@ -71,5 +72,5 @@ func writeBlocks(x *xxh, b []byte) []byte {
 		b = b[32:len(b):len(b)]
 	}
 	x.v1, x.v2, x.v3, x.v4 = v1, v2, v3, v4
-	return b
+	return n - len(b)
 }


### PR DESCRIPTION
This still needs work; the purego one got slower. It also needs a benchmark (I didn't include the quick'n'dirty one I used to measure the results because I think @ongardie-ebay has added some benchmarks for his incoming changes.)

It has a nice side effect of bypassing reslicing gotcha in the assembly.

Updates #13.