### PR TITLE
Fix minimal go version (>=1.11)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cespare/xxhash/v2
 
-go 1.13
+go 1.11


### PR DESCRIPTION
When downloading your library with go <1.13, it fails because of the requirement set in the go.mod file.