### PR TITLE
Add constructor that returns hash.Hash interface

### DIFF
--- a/xxhash.go
+++ b/xxhash.go
@@ -5,6 +5,7 @@ package xxhash
 import (
 	"encoding/binary"
 	"errors"
+	"hash"
 	"math/bits"
 )
 
@@ -46,6 +47,10 @@ func New() *Digest {
 	var d Digest
 	d.Reset()
 	return &d
+}
+
+func NewHash64() hash.Hash {
+	return New()
 }
 
 // Reset clears the Digest's state so that it can be reused.


### PR DESCRIPTION
This PR adds a constructor that returns the [`hash.Hash`](https://golang.org/pkg/hash/#Hash) interface so that this xxhash implementation may be used interchangeably with other `hash.Hash` implementations, such as in the https://github.com/elastic/beats project (see https://www.elastic.co/guide/en/beats/filebeat/master/fingerprint.html).

It leaves the existing `New` constructor as-is for backwards compatibility.