### PR TITLE
Replace ADDQ $c, r by LEAQ c(r), r in amd64 assembly

### DIFF
--- a/xxhash_amd64.s
+++ b/xxhash_amd64.s
@@ -22,7 +22,7 @@
 // It assumes that R13 has prime1v and R14 has prime2v.
 #define round(r) \
 	MOVQ  (CX), R12 \
-	ADDQ  $8, CX    \
+	LEAQ  8(CX), CX \
 	IMULQ R14, R12  \
 	ADDQ  R12, r    \
 	ROLQ  $31, r    \
@@ -101,7 +101,7 @@ afterBlocks:
 	ADDQ DX, AX
 
 	// Right now BX has len(b)-32, and we want to loop until CX > len(b)-8.
-	ADDQ $24, BX
+	LEAQ 24(BX), BX
 
 	CMPQ CX, BX
 	JG   fourByte
@@ -109,7 +109,7 @@ afterBlocks:
 wordLoop:
 	// Calculate k1.
 	MOVQ  (CX), R8
-	ADDQ  $8, CX
+	LEAQ  8(CX), CX
 	IMULQ R14, R8
 	ROLQ  $31, R8
 	IMULQ R13, R8
@@ -123,12 +123,12 @@ wordLoop:
 	JLE  wordLoop
 
 fourByte:
-	ADDQ $4, BX
+	LEAQ 4(BX), BX
 	CMPQ CX, BX
 	JG   singles
 
 	MOVL  (CX), R8
-	ADDQ  $4, CX
+	LEAQ  4(CX), CX
 	IMULQ R13, R8
 	XORQ  R8, AX
 
@@ -137,13 +137,13 @@ fourByte:
 	ADDQ  ·prime3v(SB), AX
 
 singles:
-	ADDQ $4, BX
+	LEAQ 4(BX), BX
 	CMPQ CX, BX
 	JGE  finalize
 
 singlesLoop:
 	MOVBQZX (CX), R12
-	ADDQ    $1, CX
+	LEAQ    1(CX), CX
 	IMULQ   ·prime5v(SB), R12
 	XORQ    R12, AX
 


### PR DESCRIPTION
On older CPUs such as i7-3770K, this gives a small speedup:

```
name                                  old speed      new speed      delta
Hashes/xxhash,direct,bytes,n=5B-8      854MB/s ± 0%   851MB/s ± 1%    ~     (p=0.720 n=9+10)
Hashes/xxhash,direct,string,n=5B-8     569MB/s ± 1%   571MB/s ± 1%    ~     (p=0.123 n=10+10)
Hashes/xxhash,digest,bytes,n=5B-8      234MB/s ± 1%   235MB/s ± 1%  +0.43%  (p=0.029 n=10+10)
Hashes/xxhash,digest,string,n=5B-8     210MB/s ± 0%   211MB/s ± 1%  +0.64%  (p=0.000 n=9+10)
Hashes/xxhash,direct,bytes,n=100B-8   5.57GB/s ± 0%  5.68GB/s ± 1%  +1.99%  (p=0.000 n=7+10)
Hashes/xxhash,direct,string,n=100B-8  4.91GB/s ± 0%  5.05GB/s ± 1%  +2.96%  (p=0.000 n=10+10)
Hashes/xxhash,digest,bytes,n=100B-8   3.09GB/s ± 0%  3.15GB/s ± 0%  +1.82%  (p=0.000 n=10+10)
Hashes/xxhash,digest,string,n=100B-8  2.58GB/s ± 0%  2.61GB/s ± 0%  +0.94%  (p=0.000 n=10+10)
Hashes/xxhash,direct,bytes,n=4KB-8    14.5GB/s ± 0%  14.5GB/s ± 1%  +0.30%  (p=0.017 n=10+9)
Hashes/xxhash,direct,string,n=4KB-8   14.3GB/s ± 0%  14.4GB/s ± 1%  +1.08%  (p=0.000 n=7+10)
Hashes/xxhash,digest,bytes,n=4KB-8    13.4GB/s ± 1%  13.6GB/s ± 1%  +1.24%  (p=0.000 n=10+10)
Hashes/xxhash,digest,string,n=4KB-8   13.2GB/s ± 0%  13.5GB/s ± 1%  +2.48%  (p=0.000 n=9+10)
Hashes/xxhash,direct,bytes,n=10MB-8   13.1GB/s ± 1%  13.2GB/s ± 1%  +1.12%  (p=0.000 n=10+10)
Hashes/xxhash,direct,string,n=10MB-8  13.1GB/s ± 0%  13.2GB/s ± 0%  +0.50%  (p=0.000 n=10+10)
Hashes/xxhash,digest,bytes,n=10MB-8   13.1GB/s ± 1%  13.1GB/s ± 1%    ~     (p=0.053 n=9+10)
Hashes/xxhash,digest,string,n=10MB-8  13.1GB/s ± 1%  13.2GB/s ± 0%  +0.61%  (p=0.008 n=10+9)
```