### PR TITLE
performance: optimising purego performance by expanding loops

### DIFF
--- a/xxhash_other.go
+++ b/xxhash_other.go
@@ -19,7 +19,37 @@ func Sum64(b []byte) uint64 {
 		v2 := prime2
 		v3 := uint64(0)
 		v4 := -primes[0]
-		for len(b) >= 32 {
+		for len(b) >= 128 {
+			v1 = round(v1, u64(b[0:8:len(b)]))
+			v2 = round(v2, u64(b[8:16:len(b)]))
+			v3 = round(v3, u64(b[16:24:len(b)]))
+			v4 = round(v4, u64(b[24:32:len(b)]))
+			v1 = round(v1, u64(b[32:40:len(b)]))
+			v2 = round(v2, u64(b[40:48:len(b)]))
+			v3 = round(v3, u64(b[48:56:len(b)]))
+			v4 = round(v4, u64(b[56:64:len(b)]))
+			v1 = round(v1, u64(b[64:72:len(b)]))
+			v2 = round(v2, u64(b[72:80:len(b)]))
+			v3 = round(v3, u64(b[80:88:len(b)]))
+			v4 = round(v4, u64(b[88:96:len(b)]))
+			v1 = round(v1, u64(b[96:104:len(b)]))
+			v2 = round(v2, u64(b[104:112:len(b)]))
+			v3 = round(v3, u64(b[112:120:len(b)]))
+			v4 = round(v4, u64(b[120:128:len(b)]))
+			b = b[128:len(b):len(b)]
+		}
+		if len(b) >= 64 {
+			v1 = round(v1, u64(b[0:8:len(b)]))
+			v2 = round(v2, u64(b[8:16:len(b)]))
+			v3 = round(v3, u64(b[16:24:len(b)]))
+			v4 = round(v4, u64(b[24:32:len(b)]))
+			v1 = round(v1, u64(b[32:40:len(b)]))
+			v2 = round(v2, u64(b[40:48:len(b)]))
+			v3 = round(v3, u64(b[48:56:len(b)]))
+			v4 = round(v4, u64(b[56:64:len(b)]))
+			b = b[64:len(b):len(b)]
+		}
+		if len(b) >= 32 {
 			v1 = round(v1, u64(b[0:8:len(b)]))
 			v2 = round(v2, u64(b[8:16:len(b)]))
 			v3 = round(v3, u64(b[16:24:len(b)]))
@@ -64,7 +94,37 @@ func Sum64(b []byte) uint64 {
 func writeBlocks(d *Digest, b []byte) int {
 	v1, v2, v3, v4 := d.v1, d.v2, d.v3, d.v4
 	n := len(b)
-	for len(b) >= 32 {
+	for len(b) >= 128 {
+		v1 = round(v1, u64(b[0:8:len(b)]))
+		v2 = round(v2, u64(b[8:16:len(b)]))
+		v3 = round(v3, u64(b[16:24:len(b)]))
+		v4 = round(v4, u64(b[24:32:len(b)]))
+		v1 = round(v1, u64(b[32:40:len(b)]))
+		v2 = round(v2, u64(b[40:48:len(b)]))
+		v3 = round(v3, u64(b[48:56:len(b)]))
+		v4 = round(v4, u64(b[56:64:len(b)]))
+		v1 = round(v1, u64(b[64:72:len(b)]))
+		v2 = round(v2, u64(b[72:80:len(b)]))
+		v3 = round(v3, u64(b[80:88:len(b)]))
+		v4 = round(v4, u64(b[88:96:len(b)]))
+		v1 = round(v1, u64(b[96:104:len(b)]))
+		v2 = round(v2, u64(b[104:112:len(b)]))
+		v3 = round(v3, u64(b[112:120:len(b)]))
+		v4 = round(v4, u64(b[120:128:len(b)]))
+		b = b[128:len(b):len(b)]
+	}
+	if len(b) >= 64 {
+		v1 = round(v1, u64(b[0:8:len(b)]))
+		v2 = round(v2, u64(b[8:16:len(b)]))
+		v3 = round(v3, u64(b[16:24:len(b)]))
+		v4 = round(v4, u64(b[24:32:len(b)]))
+		v1 = round(v1, u64(b[32:40:len(b)]))
+		v2 = round(v2, u64(b[40:48:len(b)]))
+		v3 = round(v3, u64(b[48:56:len(b)]))
+		v4 = round(v4, u64(b[56:64:len(b)]))
+		b = b[64:len(b):len(b)]
+	}
+	if len(b) >= 32 {
 		v1 = round(v1, u64(b[0:8:len(b)]))
 		v2 = round(v2, u64(b[8:16:len(b)]))
 		v3 = round(v3, u64(b[16:24:len(b)]))


### PR DESCRIPTION
Improves performance by up to 18% by unfolding loops

```text
benchstat old.out new.out                                                
goos: darwin
goarch: amd64
pkg: github.com/cespare/xxhash/v2
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
              │    old.out    │               new.out               │
              │    sec/op     │   sec/op     vs base                │
Sum64/4B-12      3.289n ±  0%   3.288n ± 0%        ~ (p=0.467 n=15)
Sum64/16B-12     5.876n ± 14%   6.066n ± 1%        ~ (p=0.480 n=15)
Sum64/100B-12    15.78n ±  1%   15.20n ± 1%   -3.68% (p=0.000 n=15)
Sum64/4KB-12     368.8n ±  2%   314.2n ± 0%  -14.80% (p=0.000 n=15)
Sum64/10MB-12   1123.0µ ±  5%   947.4µ ± 3%  -15.63% (p=0.000 n=15)
geomean          166.1n         155.3n        -6.50%

              │    old.out    │               new.out                │
              │      B/s      │     B/s       vs base                │
Sum64/4B-12     1.133Gi ±  0%   1.133Gi ± 0%        ~ (p=0.512 n=15)
Sum64/16B-12    2.536Gi ± 12%   2.457Gi ± 1%        ~ (p=0.486 n=15)
Sum64/100B-12   5.902Gi ±  1%   6.125Gi ± 1%   +3.79% (p=0.000 n=15)
Sum64/4KB-12    10.10Gi ±  2%   11.86Gi ± 0%  +17.39% (p=0.000 n=15)
Sum64/10MB-12   8.293Gi ±  5%   9.830Gi ± 3%  +18.53% (p=0.000 n=15)
geomean         4.270Gi         4.567Gi        +6.96%

```

Referenced RFC 1071 

Signed-off-by: aimuz <mr.imuz@gmail.com>
