### PR TITLE
Bump GitHub actions to their latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,18 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Install go
-        uses: WillAbides/setup-go-faster@v1.5.0
+        uses: WillAbides/setup-go-faster@v1.14.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test
         run: go test -count 1 -bench . -benchtime 1x ./...
@@ -32,21 +32,21 @@ jobs:
     needs: test
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.21.x, 1.22.x]
         arch: [386, arm, arm64]
     runs-on: ubuntu-latest
 
     steps:
       - name: Install go
-        uses: WillAbides/setup-go-faster@v1.5.0
+        uses: WillAbides/setup-go-faster@v1.14.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Install QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run test via qemu/binfmt
         # TODO: Run the dynamic linking tests as well. That is a little more

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package is written with optimized pure Go and also contains even faster
 assembly implementations for amd64 and arm64. If desired, the `purego` build tag
 opts into using the Go code even on those architectures.
 
-[xxHash]: http://cyan4973.github.io/xxHash/
+[xxHash]: https://xxhash.com/
 
 ## Compatibility
 

--- a/xxhash.go
+++ b/xxhash.go
@@ -1,5 +1,5 @@
 // Package xxhash implements the 64-bit variant of xxHash (XXH64) as described
-// at http://cyan4973.github.io/xxHash/.
+// at https://xxhash.com/.
 package xxhash
 
 import (


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/cespare/xxhash/actions/runs/8560595967).